### PR TITLE
Fixes to ruby client.

### DIFF
--- a/modules/swagger-codegen/src/main/resources/ruby/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api.mustache
@@ -12,11 +12,11 @@ module {{moduleName}}
 
       # {{{summary}}}
       # {{{notes}}}
-    {{#allParams}}{{#required}}  # @param {{paramName}} {{description}}
-    {{/required}}{{/allParams}}  # @param [Hash] opts the optional parameters
-    {{#allParams}}{{^required}}  # @option opts [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}
-    {{/required}}{{/allParams}}  # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
-      def {{operationId}}(context{{#allParams}}{{#required}}, {{paramName}}{{/required}}{{/allParams}})
+    {{#pathParams}}  # @param {{paramName}} {{description}}
+    {{/pathParams}}{{#hasBodyParam}}  # @param [Hash] req_body the request body parameters{{/hasBodyParam}}
+    {{#bodyParams}}  # @option req_body [{{{dataType}}}] :{{paramName}} {{description}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}} {{#required}}(required){{/required}}
+    {{/bodyParams}}  # @return [{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}nil{{/returnType}}]
+      def {{operationId}}(context{{#pathParams}}, {{paramName}}{{/pathParams}}{{#hasBodyParam}}, req_body{{/hasBodyParam}})
         local_var_path = "{{{path}}}"{{#pathParams}}.sub('{' + '{{baseName}}' + '}', {{paramName}}.to_s){{/pathParams}}
         {{#returnType}}
           {{#isListContainer}}
@@ -30,7 +30,7 @@ module {{moduleName}}
         ret = ''
         {{/returnType}}
 
-        {{httpMethodLowerCase}}(context, local_var_path, ret{{#allParams}}{{#bodyParam}}, {{paramName}}{{/bodyParam}}{{/allParams}})
+        {{httpMethodLowerCase}}(context, local_var_path, ret{{#hasBodyParam}}, req_body{{/hasBodyParam}})
 
         ret
       end

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client.mustache
@@ -3,7 +3,7 @@
 =end
 
 # base_client
-require '{{gemName}}/{{apiPackage}}/base_client'
+require '{{gemName}}/{{apiPackage}}/client_base'
 
 # APIs
 {{#apiInfo}}
@@ -15,7 +15,7 @@ require '{{importPath}}'
 module {{moduleName}}
   module {{packageName}}
     class Client
-      include BaseClient
+      include ClientBase
       {{#apiInfo}}
       {{#apis}}
       include {{classname}}

--- a/modules/swagger-codegen/src/main/resources/ruby/api_client_base.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_client_base.mustache
@@ -21,7 +21,7 @@ module {{moduleName}}
   # client to perform RESTful APIs
   module ClientBase
     def initialize(base_url, api_version, proxy_settings = nil)
-      @base_url = base_url
+      @base_url = base_url + "{{{contextPath}}}"
       @api_version = api_version.to_s
       @proxy_settings = proxy_settings
     end


### PR DESCRIPTION
Fix issue with base client module and import name
Add a single hash argument for the request body for requests that have body parameters (required or not). Also tried to cleanup the method documentation.
Add basePath in the yaml specification (contextPath in code) to the base URL in the client.

Really needs more extensive changes to be a better auto-generated client but does what TrafficCenter currently needs. I haven't looked closely as to where the upstream changes for the new Ruby client came in (specifically OpenApi v2 vs v3).